### PR TITLE
Add web app docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ uv run python your_script.py
 uv run jupyter notebook notebooks/WhiskerResponseCurves.ipynb
 ```
 
+### Web app
+
+The `web/` folder includes a small Flask example.
+Install the required packages and start the server:
+
+```bash
+uv pip install flask plotly
+python web/wall_dist_app.py
+```
+
+Open your browser to <http://127.0.0.1:5000/> and use the form to adjust
+the wall distance.
+
 
 **Git**  
 After updating notebooks, run `find . -name "*.ipynb" -exec jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace {} \;` before staging changes to clear outputs.


### PR DESCRIPTION
## Summary
- document how to set up and run the example Flask web app in the project README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `uv run python web/wall_dist_app.py` *(fails without Flask/Plotly)*
- `uv run python web/wall_dist_app.py` *(after installing dependencies)*
- `find . -name "*.ipynb" -exec jupyter nbconvert --ClearOutputPreprocessor.enabled=True --inplace {} \;` *(fails: `jupyter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614219ddf083238b5f7fdf8dfdd374